### PR TITLE
Fixed marks in Swift

### DIFF
--- a/FileHelper.swift
+++ b/FileHelper.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-//pragma mark - strip slashes
+// MARK:- strip slashes
 open class FileHelper {
 open static func stripSlashIfNeeded(_ stringWithPossibleSlash:String) -> String {
     var stringWithoutSlash:String = stringWithPossibleSlash

--- a/FileHelper.swift
+++ b/FileHelper.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// MARK:- strip slashes
+// MARK: - strip slashes
 open class FileHelper {
 open static func stripSlashIfNeeded(_ stringWithPossibleSlash:String) -> String {
     var stringWithoutSlash:String = stringWithPossibleSlash

--- a/FileZip.swift
+++ b/FileZip.swift
@@ -115,7 +115,7 @@ open class FileZip {
         
     }
     
-    //pragma mark - strip slashes
+    // MARK: - strip slashes
     
     fileprivate static func stripSlashIfNeeded(_ stringWithPossibleSlash:String) -> String {
         var stringWithoutSlash:String = stringWithPossibleSlash


### PR DESCRIPTION
In Swift, marks are '// MARK:' and not '// pragma mark'